### PR TITLE
Todo 10 delete task

### DIFF
--- a/crud/task.py
+++ b/crud/task.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 
 from db.database import get_db
 from models.task import Task as TaskModel
-from schemas.task import TaskCreate
+from schemas.task import TaskCreate, TaskUpdate
 
 
 def create_task(task: TaskCreate, db: Session = Depends(get_db)):
@@ -37,3 +37,21 @@ def get_tasks_by_user_id(user_id: int, db: Session = Depends(get_db)):
         .order_by(TaskModel.created_at)
         .all()
     )
+
+
+def update_task(task_id: str, task: TaskUpdate, db: Session = Depends(get_db)):
+    """
+    Update a task.
+
+    :param task_id: Task ID
+    :param task: Task to update
+    :param db: Database session
+    :return: Task updated
+    """
+
+    task_db = db.query(TaskModel).filter(TaskModel.id == task_id).first()
+    task_db.title = task.title
+    task_db.description = task.description
+    db.commit()
+    db.refresh(task_db)
+    return task_db

--- a/crud/task.py
+++ b/crud/task.py
@@ -37,3 +37,22 @@ def get_tasks_by_user_id(user_id: int, db: Session = Depends(get_db)):
         .order_by(TaskModel.created_at)
         .all()
     )
+
+
+def delete_task_by_id(task_id: str, db: Session = Depends(get_db)):
+    """
+    Delete a task by ID.
+
+    :param task_id: Task ID
+    :param db: Database session
+    :return: None
+    """
+
+    task = db.query(TaskModel).filter(TaskModel.id == task_id).first()
+
+    if not task:
+        return None
+
+    db.delete(task)
+    db.commit()
+    return None

--- a/crud/task.py
+++ b/crud/task.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 
 from db.database import get_db
 from models.task import Task as TaskModel
-from schemas.task import TaskCreate, TaskUpdate
+from schemas.task import TaskCreate
 
 
 def create_task(task: TaskCreate, db: Session = Depends(get_db)):
@@ -37,21 +37,3 @@ def get_tasks_by_user_id(user_id: int, db: Session = Depends(get_db)):
         .order_by(TaskModel.created_at)
         .all()
     )
-
-
-def update_task(task_id: str, task: TaskUpdate, db: Session = Depends(get_db)):
-    """
-    Update a task.
-
-    :param task_id: Task ID
-    :param task: Task to update
-    :param db: Database session
-    :return: Task updated
-    """
-
-    task_db = db.query(TaskModel).filter(TaskModel.id == task_id).first()
-    task_db.title = task.title
-    task_db.description = task.description
-    db.commit()
-    db.refresh(task_db)
-    return task_db

--- a/crud/task.py
+++ b/crud/task.py
@@ -38,6 +38,7 @@ def get_tasks_by_user_id(user_id: int, db: Session = Depends(get_db)):
         .all()
     )
 
+
 def delete_task_by_id(task_id: str, db: Session = Depends(get_db)):
     """
     Delete a task by ID.
@@ -55,7 +56,8 @@ def delete_task_by_id(task_id: str, db: Session = Depends(get_db)):
     db.delete(task)
     db.commit()
     return None
-  
+
+
 def update_task(task_id: str, task: TaskUpdate, db: Session = Depends(get_db)):
     """
     Update a task.
@@ -72,6 +74,7 @@ def update_task(task_id: str, task: TaskUpdate, db: Session = Depends(get_db)):
     db.commit()
     db.refresh(task_db)
     return task_db
+
 
 def get_task_by_id(task_id: str, db: Session = Depends(get_db)):
     """

--- a/crud/task.py
+++ b/crud/task.py
@@ -56,3 +56,14 @@ def delete_task_by_id(task_id: str, db: Session = Depends(get_db)):
     db.delete(task)
     db.commit()
     return None
+
+
+def get_task_by_id(task_id: str, db: Session = Depends(get_db)):
+    """
+    Get a task by ID.
+    :param task_id: Task ID
+    :param db: Database session
+    :return: Task
+    """
+
+    return db.query(TaskModel).filter(TaskModel.id == task_id).first()

--- a/routers/task.py
+++ b/routers/task.py
@@ -4,9 +4,9 @@ from fastapi import APIRouter, HTTPException, Depends, status
 from sqlalchemy.orm import Session
 
 from db.database import get_db
-from crud.task import create_task, get_tasks_by_user_id, update_task, delete_task
+from crud.task import create_task, get_tasks_by_user_id
 from crud.user import get_user_by_id, get_user_by_username
-from schemas.task import TaskCreate, TaskResponse, TaskUpdate
+from schemas.task import TaskCreate, TaskResponse
 from auth.auth import jwks, get_current_user
 from auth.JWTBearer import JWTBearer
 
@@ -108,45 +108,4 @@ async def get_tasks_by_user(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Internal server error while getting tasks",
-        )
-
-
-@router.put(
-    "/tasks/{task_id}",
-    response_model=TaskResponse,
-    status_code=status.HTTP_200_OK,
-    dependencies=[Depends(auth)],
-)
-async def update_task_route(
-    task_id: str, task_data: TaskUpdate, db: Session = Depends(get_db)
-):
-    """
-    Update a task.
-
-    :param task_id: Task ID
-    :param task_data: Task data to update
-    :param db: Database session
-    :return: Task updated
-
-    :raises HTTPException: If the task does not exist or if there is an internal server error
-    :raises Exception: If there is an internal server error
-    """
-
-    try:
-        # Update the task
-        updated_task = update_task(task_id=task_id, task=task_data, db=db)
-        print(updated_task)
-
-        # If successful, return the updated task in the response
-        return updated_task
-
-    except HTTPException as http_exc:
-        # Re-raise HTTP exceptions to maintain the status code
-        raise http_exc
-
-    except Exception as e:
-        logging.error(f"Failed to update task: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Internal server error while updating the task",
         )

--- a/routers/task.py
+++ b/routers/task.py
@@ -4,9 +4,9 @@ from fastapi import APIRouter, HTTPException, Depends, status
 from sqlalchemy.orm import Session
 
 from db.database import get_db
-from crud.task import create_task, get_tasks_by_user_id
+from crud.task import create_task, get_tasks_by_user_id, update_task, delete_task
 from crud.user import get_user_by_id, get_user_by_username
-from schemas.task import TaskCreate, TaskResponse
+from schemas.task import TaskCreate, TaskResponse, TaskUpdate
 from auth.auth import jwks, get_current_user
 from auth.JWTBearer import JWTBearer
 
@@ -108,4 +108,45 @@ async def get_tasks_by_user(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Internal server error while getting tasks",
+        )
+
+
+@router.put(
+    "/tasks/{task_id}",
+    response_model=TaskResponse,
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(auth)],
+)
+async def update_task_route(
+    task_id: str, task_data: TaskUpdate, db: Session = Depends(get_db)
+):
+    """
+    Update a task.
+
+    :param task_id: Task ID
+    :param task_data: Task data to update
+    :param db: Database session
+    :return: Task updated
+
+    :raises HTTPException: If the task does not exist or if there is an internal server error
+    :raises Exception: If there is an internal server error
+    """
+
+    try:
+        # Update the task
+        updated_task = update_task(task_id=task_id, task=task_data, db=db)
+        print(updated_task)
+
+        # If successful, return the updated task in the response
+        return updated_task
+
+    except HTTPException as http_exc:
+        # Re-raise HTTP exceptions to maintain the status code
+        raise http_exc
+
+    except Exception as e:
+        logging.error(f"Failed to update task: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error while updating the task",
         )

--- a/routers/task.py
+++ b/routers/task.py
@@ -4,7 +4,12 @@ from fastapi import APIRouter, HTTPException, Depends, status
 from sqlalchemy.orm import Session
 
 from db.database import get_db
-from crud.task import create_task, get_tasks_by_user_id, delete_task_by_id
+from crud.task import (
+    create_task,
+    get_tasks_by_user_id,
+    delete_task_by_id,
+    get_task_by_id,
+)
 from crud.user import get_user_by_id, get_user_by_username
 from schemas.task import TaskCreate, TaskResponse
 from auth.auth import jwks, get_current_user
@@ -129,6 +134,12 @@ async def delete_task_by_id_route(task_id: str, db: Session = Depends(get_db)):
     """
 
     try:
+        task = get_task_by_id(task_id=task_id, db=db)
+        if task is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Task with id {task_id} not found",
+            )
         # Delete the task by ID
         delete_task_by_id(task_id=task_id, db=db)
 

--- a/routers/task.py
+++ b/routers/task.py
@@ -9,6 +9,7 @@ from crud.task import (
     get_tasks_by_user_id,
     delete_task_by_id,
     get_task_by_id,
+    update_task,
 )
 from crud.user import get_user_by_id, get_user_by_username
 from schemas.task import TaskCreate, TaskResponse, TaskUpdate
@@ -128,7 +129,7 @@ async def delete_task_by_id_route(task_id: str, db: Session = Depends(get_db)):
     :param task_id: Task ID
     :param db: Database session
     :return: None
-    
+
     :raises HTTPException: If the task does not exist or if there is an internal server error
     :raises Exception: If there is an internal server error
     """
@@ -156,7 +157,8 @@ async def delete_task_by_id_route(task_id: str, db: Session = Depends(get_db)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Internal server error while deleting the task",
         )
-        
+
+
 @router.put(
     "/tasks/{task_id}",
     response_model=TaskResponse,

--- a/tests/crud/test_task.py
+++ b/tests/crud/test_task.py
@@ -8,7 +8,7 @@ from db.database import get_db
 from main import app
 from models.user import User as UserModel
 from models.task import Task as TaskModel
-from crud.task import create_task, get_tasks_by_user_id
+from crud.task import create_task, get_tasks_by_user_id, delete_task_by_id
 from schemas.task import TaskCreate
 
 # Configuração de logging para facilitar a depuração
@@ -131,3 +131,23 @@ def test_get_tasks_by_user_id(test_db, test_user: UserModel):
     assert len(tasks) == 2  # Deve retornar 2 tasks
     assert tasks[0].title == task_data_1.title or tasks[0].title == task_data_2.title
     assert tasks[1].title == task_data_1.title or tasks[1].title == task_data_2.title
+
+
+def test_delete_task_by_id(test_db, test_user: UserModel):
+    """
+    Testa a função de deletar uma Task pelo ID.
+    """
+    # Criar uma Task associada ao usuário de teste
+    task_data = TaskCreate(
+        title="Test Task", description="This is a test task", user_id=test_user.id
+    )
+    task_created = create_task(task_data, test_db)
+
+    # Chama a função para deletar a task pelo ID
+    delete_task_by_id(task_created.id, test_db)
+
+    # Verifica se a Task foi removida do banco de dados
+    task_in_db = (
+        test_db.query(TaskModel).filter(TaskModel.id == task_created.id).first()
+    )
+    assert task_in_db is None  # A task não deve existir mais no banco de dados

--- a/tests/routers/test_task.py
+++ b/tests/routers/test_task.py
@@ -353,7 +353,8 @@ def test_update_task_internal_server_error(mock_jwt_bearer, mock_update_task):
 
     app.dependency_overrides = {}
 
-    @patch("routers.task.get_task_by_id")  # Mock get_task_by_id
+
+@patch("routers.task.get_task_by_id")  # Mock get_task_by_id
 @patch("routers.task.delete_task_by_id")  # Mock delete_task_by_id
 @patch.object(
     JWTBearer, "__call__", return_value=credentials
@@ -406,6 +407,7 @@ def test_delete_task_by_id_not_found(mock_jwt_bearer, mock_get_task_by_id):
     assert response.json()["detail"] == f"Task with id {task_id} not found"
 
     app.dependency_overrides = {}
+
 
 @patch("routers.task.get_task_by_id", return_value=Mock(id="1"))  # Mock get_task_by_id
 @patch(

--- a/tests/routers/test_task.py
+++ b/tests/routers/test_task.py
@@ -249,3 +249,82 @@ def test_get_tasks_internal_server_error(
     assert response.json()["detail"] == "Internal server error while getting tasks"
 
     app.dependency_overrides = {}
+
+
+@patch("routers.task.get_task_by_id")  # Mock get_task_by_id
+@patch("routers.task.delete_task_by_id")  # Mock delete_task_by_id
+@patch.object(
+    JWTBearer, "__call__", return_value=credentials
+)  # Mock the JWTBearer dependency
+def test_delete_task_by_id_success(
+    mock_jwt_bearer, mock_delete_task_by_id, mock_get_task_by_id
+):
+    """Test successful deletion of a task."""
+
+    app.dependency_overrides[auth] = lambda: credentials
+
+    # Task ID for the task to delete
+    task_id = "1"
+
+    # Simulate finding the task
+    mock_task = Mock(id=task_id)
+    mock_get_task_by_id.return_value = mock_task
+
+    # Make the delete request
+    response = client.delete(f"/tasks/{task_id}")
+
+    # Assert the response status code is 204 (No Content)
+    assert response.status_code == 204
+
+    # Capture the actual DB session passed in the function call
+    # Use the actual db object passed in the test to assert
+    mock_delete_task_by_id.assert_called_once()
+
+    # Reset dependency overrides
+    app.dependency_overrides = {}
+
+
+@patch("routers.task.get_task_by_id")  # Mock get_task_by_id
+@patch.object(JWTBearer, "__call__", return_value=credentials)
+def test_delete_task_by_id_not_found(mock_jwt_bearer, mock_get_task_by_id):
+    """Test deletion when task is not found (404 error)."""
+
+    app.dependency_overrides[auth] = lambda: credentials
+
+    task_id = "non_existing_task_id"
+
+    # Simulate task not being found
+    mock_get_task_by_id.return_value = None
+
+    # Make the delete request
+    response = client.delete(f"/tasks/{task_id}")
+
+    # Assert 404 status code
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"Task with id {task_id} not found"
+
+    app.dependency_overrides = {}
+
+
+@patch("routers.task.get_task_by_id", return_value=Mock(id="1"))  # Mock get_task_by_id
+@patch(
+    "routers.task.delete_task_by_id", side_effect=Exception("Simulated DB error")
+)  # Mock delete_task_by_id
+@patch.object(JWTBearer, "__call__", return_value=credentials)
+def test_delete_task_by_id_internal_server_error(
+    mock_jwt_bearer, mock_delete_task_by_id, mock_get_task_by_id
+):
+    """Test deletion when there's an internal server error."""
+
+    app.dependency_overrides[auth] = lambda: credentials
+
+    task_id = "1"
+
+    # Make the delete request
+    response = client.delete(f"/tasks/{task_id}")
+
+    # Assert 500 status code
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Internal server error while deleting the task"
+
+    app.dependency_overrides = {}


### PR DESCRIPTION
This pull request introduces functionality to delete tasks by their ID and includes corresponding tests. The most important changes include the addition of new functions to handle task deletion, updates to the router to include a new endpoint, and the implementation of tests for the new functionality.

New functionality for task deletion:

* [`crud/task.py`](diffhunk://#diff-982081e8c6eac13fc8776804bf95157890e9ede851bf73f45bf88b71175a8ba0R40-R69): Added `delete_task_by_id` and `get_task_by_id` functions to handle task deletion and retrieval by ID.
* [`routers/task.py`](diffhunk://#diff-34a85b9525bb969b96c04301cd37cd66bb907856626d02f7b433ffee46539f86L7-R12): Updated imports and added a new endpoint `delete_task_by_id_route` to handle DELETE requests for tasks by ID. [[1]](diffhunk://#diff-34a85b9525bb969b96c04301cd37cd66bb907856626d02f7b433ffee46539f86L7-R12) [[2]](diffhunk://#diff-34a85b9525bb969b96c04301cd37cd66bb907856626d02f7b433ffee46539f86R117-R158)

Testing:

* [`tests/crud/test_task.py`](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01L11-R11): Added `test_delete_task_by_id` to verify the deletion functionality in the CRUD layer. [[1]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01L11-R11) [[2]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01R134-R153)
* [`tests/routers/test_task.py`](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R252-R330): Added tests `test_delete_task_by_id_success`, `test_delete_task_by_id_not_found`, and `test_delete_task_by_id_internal_server_error` to ensure the new endpoint behaves correctly under different scenarios.