### PR TITLE
Todo 8 add task

### DIFF
--- a/crud/task.py
+++ b/crud/task.py
@@ -6,7 +6,7 @@ from models.task import Task as TaskModel
 from schemas.task import TaskCreate
 
 
-def create_task(task: TaskCreate, db: Session = Depends(get_db)):
+def create_task(task: TaskCreate, user_id: str, db: Session = Depends(get_db)):
     """
     Create a task.
 
@@ -15,14 +15,14 @@ def create_task(task: TaskCreate, db: Session = Depends(get_db)):
     :return: Task created
     """
 
-    task_db = TaskModel(**task.model_dump())
-    db.add(task_db)
+    new_task = TaskModel(**task.model_dump(), user_id=user_id)
+    db.add(new_task)
     db.commit()
-    db.refresh(task_db)
-    return task_db
+    db.refresh(new_task)
+    return new_task
 
 
-def get_tasks_by_user_id(user_id: int, db: Session = Depends(get_db)):
+def get_tasks_by_user_id(user_id: str, db: Session = Depends(get_db)):
     """
     Get all tasks for a specific user.
 

--- a/routers/task.py
+++ b/routers/task.py
@@ -21,7 +21,11 @@ auth = JWTBearer(jwks)
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(auth)],
 )
-async def create_new_task(task_data: TaskCreate, db: Session = Depends(get_db)):
+async def create_new_task(
+    task_data: TaskCreate,
+    user_username: str = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
     """
     Create a new task for a specific user.
 
@@ -35,17 +39,17 @@ async def create_new_task(task_data: TaskCreate, db: Session = Depends(get_db)):
     """
 
     # Check if the user exists in the database
-    user = get_user_by_id(task_data.user_id, db=db)
+    user = get_user_by_username(user_username, db=db)
 
     if not user:
-        logging.error(f"User with id {task_data.user_id} not found.")
+        logging.error(f"User with username {user_username} not found.")
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
 
     try:
         # Create a new task
-        new_task = create_task(task=task_data, db=db)
+        new_task = create_task(task=task_data, user_id=user.id, db=db)
 
         # If successful, return the task in the response
         return new_task

--- a/schemas/task.py
+++ b/schemas/task.py
@@ -5,7 +5,6 @@ from datetime import datetime
 class TaskCreate(BaseModel):
     title: str
     description: str
-    user_id: str
 
 
 class TaskResponse(BaseModel):

--- a/tests/crud/test_task.py
+++ b/tests/crud/test_task.py
@@ -8,7 +8,13 @@ from db.database import get_db
 from main import app
 from models.user import User as UserModel
 from models.task import Task as TaskModel
-from crud.task import create_task, get_tasks_by_user_id, update_task, get_task_by_id, delete_task_by_id
+from crud.task import (
+    create_task,
+    get_tasks_by_user_id,
+    update_task,
+    get_task_by_id,
+    delete_task_by_id,
+)
 from schemas.task import TaskCreate, TaskUpdate
 
 # Configuração de logging para facilitar a depuração
@@ -127,6 +133,7 @@ def test_get_tasks_by_user_id(test_db, test_user: UserModel):
     assert tasks[0].title == task_data_1.title or tasks[0].title == task_data_2.title
     assert tasks[1].title == task_data_1.title or tasks[1].title == task_data_2.title
 
+
 def test_delete_task_by_id(test_db, test_user: UserModel):
     """
     Testa a função de deletar uma Task pelo ID.
@@ -135,7 +142,7 @@ def test_delete_task_by_id(test_db, test_user: UserModel):
     task_data = TaskCreate(
         title="Test Task", description="This is a test task", user_id=test_user.id
     )
-    task_created = create_task(task_data, test_db)
+    task_created = create_task(task=task_data, user_id=test_user.id, db=test_db)
 
     # Chama a função para deletar a task pelo ID
     delete_task_by_id(task_created.id, test_db)
@@ -145,7 +152,8 @@ def test_delete_task_by_id(test_db, test_user: UserModel):
         test_db.query(TaskModel).filter(TaskModel.id == task_created.id).first()
     )
     assert task_in_db is None  # A task não deve existir mais no banco de dados
-    
+
+
 def test_update_task(test_db, test_user: UserModel):
     """
     Testa a função de atualização de uma Task no banco de dados.
@@ -156,7 +164,7 @@ def test_update_task(test_db, test_user: UserModel):
         description="This is a test task",
         user_id=test_user.id,  # Relaciona a task com o usuário de teste
     )
-    task_created = create_task(task=task_data, db=test_db)
+    task_created = create_task(task=task_data, user_id=test_user.id, db=test_db)
 
     # Atualiza os dados da Task
     task_data_update = TaskUpdate(
@@ -191,7 +199,7 @@ def test_get_task_by_id(test_db, test_user: UserModel):
         description="This is a test task",
         user_id=test_user.id,  # Relaciona a task com o usuário de teste
     )
-    task_created = create_task(task=task_data, db=test_db)
+    task_created = create_task(task=task_data, user_id=test_user.id, db=test_db)
 
     # Chama a função para obter a task pelo ID
     task = get_task_by_id(task_id=task_created.id, db=test_db)

--- a/tests/crud/test_task.py
+++ b/tests/crud/test_task.py
@@ -89,11 +89,10 @@ def test_create_task(test_db, test_user: UserModel):
     task_data = TaskCreate(
         title="Test Task",
         description="This is a test task",
-        user_id=test_user.id,  # Relaciona a task com o usuário de teste
     )
 
     # Chama a função para criar a task
-    task_created = create_task(task_data, test_db)
+    task_created = create_task(task=task_data, user_id=test_user.id, db=test_db)
 
     # Verifica se a Task foi criada corretamente
     assert task_created.title == task_data.title
@@ -113,16 +112,12 @@ def test_get_tasks_by_user_id(test_db, test_user: UserModel):
     Testa a função de obter todas as Tasks de um usuário específico.
     """
     # Criar algumas Tasks associadas ao usuário de teste
-    task_data_1 = TaskCreate(
-        title="Test Task 1", description="This is test task 1", user_id=test_user.id
-    )
-    task_data_2 = TaskCreate(
-        title="Test Task 2", description="This is test task 2", user_id=test_user.id
-    )
+    task_data_1 = TaskCreate(title="Test Task 1", description="This is test task 1")
+    task_data_2 = TaskCreate(title="Test Task 2", description="This is test task 2")
 
     # Criar as Tasks no banco de dados
-    create_task(task_data_1, test_db)
-    create_task(task_data_2, test_db)
+    create_task(task=task_data_1, user_id=test_user.id, db=test_db)
+    create_task(task=task_data_2, user_id=test_user.id, db=test_db)
 
     # Chama a função para obter as tasks pelo user_id
     tasks = get_tasks_by_user_id(user_id=test_user.id, db=test_db)


### PR DESCRIPTION
This pull request updates the task creation and retrieval process to use `username` instead of `user_id` and adjusts the tests accordingly. The most important changes include modifying function signatures, updating database operations, and altering test cases to reflect these changes.

### Function and Database Updates:

* [`crud/task.py`](diffhunk://#diff-982081e8c6eac13fc8776804bf95157890e9ede851bf73f45bf88b71175a8ba0L9-R9): Modified `create_task` and `get_tasks_by_user_id` functions to use `user_id` as a parameter and updated the task creation logic to include `user_id`. [[1]](diffhunk://#diff-982081e8c6eac13fc8776804bf95157890e9ede851bf73f45bf88b71175a8ba0L9-R9) [[2]](diffhunk://#diff-982081e8c6eac13fc8776804bf95157890e9ede851bf73f45bf88b71175a8ba0L18-R25)
* [`routers/task.py`](diffhunk://#diff-34a85b9525bb969b96c04301cd37cd66bb907856626d02f7b433ffee46539f86L24-R28): Updated `create_new_task` function to use `username` for user identification and updated the user retrieval logic to use `get_user_by_username` instead of `get_user_by_id`. [[1]](diffhunk://#diff-34a85b9525bb969b96c04301cd37cd66bb907856626d02f7b433ffee46539f86L24-R28) [[2]](diffhunk://#diff-34a85b9525bb969b96c04301cd37cd66bb907856626d02f7b433ffee46539f86L38-R52)

### Schema Changes:

* [`schemas/task.py`](diffhunk://#diff-8b08b8c4f1e14482f90493cdd71b696ca2000596919bc70171d67a9db22b4b79L8): Removed `user_id` from the `TaskCreate` schema.

### Test Updates:

* [`tests/crud/test_task.py`](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01L92-R95): Adjusted test cases for `create_task` and `get_tasks_by_user_id` to align with the new function signatures and logic. [[1]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01L92-R95) [[2]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01L116-R120)
* [`tests/routers/test_task.py`](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R41-R50): Updated test cases for `create_new_task` route to mock `get_user_by_username` and adjusted dependency overrides and assertions accordingly. [[1]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R41-R50) [[2]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93L57) [[3]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93L89-R105) [[4]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93L121-R132) [[5]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93L137)