### PR TITLE
Todo 11 mark task progress

### DIFF
--- a/crud/task.py
+++ b/crud/task.py
@@ -71,6 +71,7 @@ def update_task(task_id: str, task: TaskUpdate, db: Session = Depends(get_db)):
     task_db = db.query(TaskModel).filter(TaskModel.id == task_id).first()
     task_db.title = task.title
     task_db.description = task.description
+    task_db.status = task.status
     db.commit()
     db.refresh(task_db)
     return task_db

--- a/models/task.py
+++ b/models/task.py
@@ -12,6 +12,7 @@ class Task(Base):
     id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     title = Column(String(50), nullable=False)
     description = Column(String(200))
+    status = Column(String(5), default="todo", nullable=False)
     created_at = Column(
         DateTime(timezone=True),
         index=True,

--- a/schemas/task.py
+++ b/schemas/task.py
@@ -11,9 +11,11 @@ class TaskResponse(BaseModel):
     id: str
     title: str
     description: str
+    status: str
     created_at: datetime
 
 
 class TaskUpdate(BaseModel):
     title: str
     description: str
+    status: str

--- a/tests/crud/test_task.py
+++ b/tests/crud/test_task.py
@@ -170,6 +170,7 @@ def test_update_task(test_db, test_user: UserModel):
     task_data_update = TaskUpdate(
         title="Updated Task",
         description="This is an updated task",
+        status="done",
     )
     task_updated = update_task(
         task_id=task_created.id, task=task_data_update, db=test_db
@@ -186,6 +187,7 @@ def test_update_task(test_db, test_user: UserModel):
     assert task_in_db is not None
     assert task_in_db.title == task_data_update.title
     assert task_in_db.description == task_data_update.description
+    assert task_in_db.status == task_data_update.status
     assert task_in_db.user_id == test_user.id
 
 

--- a/tests/routers/test_task.py
+++ b/tests/routers/test_task.py
@@ -62,6 +62,7 @@ def test_create_new_task(mock_jwt_bearer, mock_create_task, mock_get_user_by_use
         id="1",
         title="Test Task",
         description="Test Description",
+        status="todo",
         created_at=datetime.datetime.now(),
     )
 
@@ -82,6 +83,7 @@ def test_create_new_task(mock_jwt_bearer, mock_create_task, mock_get_user_by_use
     assert task_created["id"] == mock_task.id
     assert task_created["title"] == task_data["title"]
     assert task_created["description"] == task_data["description"]
+    assert task_created["status"] == "todo"
     assert task_created["created_at"] == mock_task.created_at.isoformat()
 
     app.dependency_overrides = {}
@@ -178,12 +180,14 @@ def test_get_tasks_by_user(
         id="1",
         title="Task 1",
         description="Description 1",
+        status="todo",
         created_at=datetime.datetime.now(),
     )
     mock_task2 = TaskResponse(
         id="2",
         title="Task 2",
         description="Description 2",
+        status="todo",
         created_at=datetime.datetime.now(),
     )
     mock_get_tasks_by_user_id.return_value = [mock_task1, mock_task2]
@@ -199,8 +203,10 @@ def test_get_tasks_by_user(
     assert len(tasks) == 2
     assert tasks[0]["title"] == mock_task1.title
     assert tasks[0]["description"] == mock_task1.description
+    assert tasks[0]["status"] == mock_task1.status
     assert tasks[1]["title"] == mock_task2.title
     assert tasks[1]["description"] == mock_task2.description
+    assert tasks[1]["status"] == mock_task2.status
 
     # Reset the overrides to not interfere with other tests
     app.dependency_overrides = {}
@@ -267,12 +273,14 @@ def test_update_task_success(mock_jwt_bearer, mock_update_task, mock_get_task_by
     updated_task_data = {
         "title": "Updated Task",
         "description": "Updated Description",
+        "status": "done",
     }
 
     mock_task = TaskResponse(
         id=task_id,
         title="Updated Task",
         description="Updated Description",
+        status="done",
         created_at=datetime.datetime.now(),
     )
 
@@ -295,6 +303,7 @@ def test_update_task_success(mock_jwt_bearer, mock_update_task, mock_get_task_by
     assert updated_task["id"] == mock_task.id
     assert updated_task["title"] == updated_task_data["title"]
     assert updated_task["description"] == updated_task_data["description"]
+    assert updated_task["status"] == "done"
 
     app.dependency_overrides = {}
 
@@ -310,6 +319,7 @@ def test_update_task_not_found(mock_jwt_bearer, mock_update_task):
     updated_task_data = {
         "title": "Updated Task",
         "description": "Updated Description",
+        "status": "done",
     }
 
     headers = {"Authorization": "Bearer token"}
@@ -339,6 +349,7 @@ def test_update_task_internal_server_error(mock_jwt_bearer, mock_update_task):
     updated_task_data = {
         "title": "Updated Task",
         "description": "Updated Description",
+        "status": "done",
     }
 
     headers = {"Authorization": "Bearer token"}


### PR DESCRIPTION
This pull request introduces a new `status` field to the `Task` model and updates various parts of the codebase to handle this new field. The changes include updates to the database model, schemas, CRUD operations, and tests.

### Model and Schema Updates:
* [`models/task.py`](diffhunk://#diff-382460ec8d319592278a2d21a0ee25c85c58dbdcc217120c9138925b0530dfd0R15): Added `status` field to the `Task` model with a default value of "todo". (`[models/task.pyR15](diffhunk://#diff-382460ec8d319592278a2d21a0ee25c85c58dbdcc217120c9138925b0530dfd0R15)`)
* [`schemas/task.py`](diffhunk://#diff-8b08b8c4f1e14482f90493cdd71b696ca2000596919bc70171d67a9db22b4b79R14-R21): Added `status` field to the `TaskResponse` and `TaskUpdate` schemas. (`[schemas/task.pyR14-R21](diffhunk://#diff-8b08b8c4f1e14482f90493cdd71b696ca2000596919bc70171d67a9db22b4b79R14-R21)`)

### CRUD Operation Updates:
* [`crud/task.py`](diffhunk://#diff-982081e8c6eac13fc8776804bf95157890e9ede851bf73f45bf88b71175a8ba0R74): Updated the `update_task` function to handle the new `status` field. (`[crud/task.pyR74](diffhunk://#diff-982081e8c6eac13fc8776804bf95157890e9ede851bf73f45bf88b71175a8ba0R74)`)

### Test Updates:
* [`tests/crud/test_task.py`](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01R173): Updated `test_update_task` to include checks for the `status` field. (`[[1]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01R173)`, `[[2]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01R190)`)
* [`tests/routers/test_task.py`](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R65): Updated various test functions to include the `status` field in task creation and update scenarios. (`[[1]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R65)`, `[[2]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R86)`, `[[3]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R183-R190)`, `[[4]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R206-R209)`, `[[5]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R276-R283)`, `[[6]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R306)`, `[[7]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R322)`, `[[8]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R352)`)