### PR TITLE
Todo 15 set task priority

### DIFF
--- a/crud/task.py
+++ b/crud/task.py
@@ -72,6 +72,7 @@ def update_task(task_id: str, task: TaskUpdate, db: Session = Depends(get_db)):
     task_db.title = task.title
     task_db.description = task.description
     task_db.status = task.status
+    task_db.priority = task.priority
     db.commit()
     db.refresh(task_db)
     return task_db

--- a/models/task.py
+++ b/models/task.py
@@ -12,7 +12,8 @@ class Task(Base):
     id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     title = Column(String(50), nullable=False)
     description = Column(String(200))
-    status = Column(String(5), default="todo", nullable=False)
+    status = Column(String(6), default="todo", nullable=False)
+    priority = Column(String(5), nullable=False)
     created_at = Column(
         DateTime(timezone=True),
         index=True,

--- a/schemas/task.py
+++ b/schemas/task.py
@@ -1,10 +1,12 @@
 from pydantic import BaseModel
 from datetime import datetime
+from typing import Optional
 
 
 class TaskCreate(BaseModel):
     title: str
     description: str
+    priority: str
 
 
 class TaskResponse(BaseModel):
@@ -12,6 +14,7 @@ class TaskResponse(BaseModel):
     title: str
     description: str
     status: str
+    priority: str
     created_at: datetime
 
 
@@ -19,3 +22,4 @@ class TaskUpdate(BaseModel):
     title: str
     description: str
     status: str
+    priority: str

--- a/tests/crud/test_task.py
+++ b/tests/crud/test_task.py
@@ -88,22 +88,18 @@ def create_test_user(test_db):
     test_db.commit()  # Comita as alterações no banco de dados
 
 
-def test_create_task(test_db, test_user: UserModel):
+def test_create_task_with_priority(test_db, test_user: UserModel):
     """
     Testa a função de criação de uma Task no banco de dados.
     """
     task_data = TaskCreate(
         title="Test Task",
         description="This is a test task",
+        priority="high",
     )
 
     # Chama a função para criar a task
     task_created = create_task(task=task_data, user_id=test_user.id, db=test_db)
-
-    # Verifica se a Task foi criada corretamente
-    assert task_created.title == task_data.title
-    assert task_created.description == task_data.description
-    assert task_created.user_id == test_user.id
 
     # Verifica se a Task foi salva no banco de dados
     task_in_db = (
@@ -111,6 +107,9 @@ def test_create_task(test_db, test_user: UserModel):
     )
     assert task_in_db is not None
     assert task_in_db.title == task_data.title
+    assert task_in_db.description == task_data.description
+    assert task_in_db.priority == task_data.priority
+    assert task_in_db.user_id == test_user.id
 
 
 def test_get_tasks_by_user_id(test_db, test_user: UserModel):
@@ -118,8 +117,12 @@ def test_get_tasks_by_user_id(test_db, test_user: UserModel):
     Testa a função de obter todas as Tasks de um usuário específico.
     """
     # Criar algumas Tasks associadas ao usuário de teste
-    task_data_1 = TaskCreate(title="Test Task 1", description="This is test task 1")
-    task_data_2 = TaskCreate(title="Test Task 2", description="This is test task 2")
+    task_data_1 = TaskCreate(
+        title="Test Task 1", description="This is test task 1", priority="low"
+    )
+    task_data_2 = TaskCreate(
+        title="Test Task 2", description="This is test task 2", priority="high"
+    )
 
     # Criar as Tasks no banco de dados
     create_task(task=task_data_1, user_id=test_user.id, db=test_db)
@@ -140,7 +143,10 @@ def test_delete_task_by_id(test_db, test_user: UserModel):
     """
     # Criar uma Task associada ao usuário de teste
     task_data = TaskCreate(
-        title="Test Task", description="This is a test task", user_id=test_user.id
+        title="Test Task",
+        description="This is a test task",
+        priority="low",
+        user_id=test_user.id,
     )
     task_created = create_task(task=task_data, user_id=test_user.id, db=test_db)
 
@@ -162,6 +168,7 @@ def test_update_task(test_db, test_user: UserModel):
     task_data = TaskCreate(
         title="Test Task",
         description="This is a test task",
+        priority="low",
         user_id=test_user.id,  # Relaciona a task com o usuário de teste
     )
     task_created = create_task(task=task_data, user_id=test_user.id, db=test_db)
@@ -170,15 +177,12 @@ def test_update_task(test_db, test_user: UserModel):
     task_data_update = TaskUpdate(
         title="Updated Task",
         description="This is an updated task",
+        priority="high",
         status="done",
     )
     task_updated = update_task(
         task_id=task_created.id, task=task_data_update, db=test_db
     )
-
-    # Verifica se a Task foi atualizada corretamente
-    assert task_updated.title == task_data_update.title
-    assert task_updated.description == task_data_update.description
 
     # Verifica se a Task foi atualizada no banco de dados
     task_in_db = (
@@ -187,6 +191,7 @@ def test_update_task(test_db, test_user: UserModel):
     assert task_in_db is not None
     assert task_in_db.title == task_data_update.title
     assert task_in_db.description == task_data_update.description
+    assert task_in_db.priority == task_data_update.priority
     assert task_in_db.status == task_data_update.status
     assert task_in_db.user_id == test_user.id
 
@@ -199,6 +204,7 @@ def test_get_task_by_id(test_db, test_user: UserModel):
     task_data = TaskCreate(
         title="Test Task",
         description="This is a test task",
+        priority="low",
         user_id=test_user.id,  # Relaciona a task com o usuário de teste
     )
     task_created = create_task(task=task_data, user_id=test_user.id, db=test_db)
@@ -210,4 +216,5 @@ def test_get_task_by_id(test_db, test_user: UserModel):
     assert task is not None
     assert task.title == task_data.title
     assert task.description == task_data.description
+    assert task.priority == task_data.priority
     assert task.user_id == test_user.id

--- a/tests/routers/test_task.py
+++ b/tests/routers/test_task.py
@@ -37,7 +37,6 @@ def reset_mock_db(mock_db):
     mock_db.reset_mock()
 
 
-# Test for create_new_task route
 @patch("routers.task.get_user_by_username")  # Mock the get_user_by_id dependency
 @patch("routers.task.create_task")  # Mock the create_task dependency
 @patch.object(
@@ -56,6 +55,7 @@ def test_create_new_task(mock_jwt_bearer, mock_create_task, mock_get_user_by_use
     task_data = {
         "title": "Test Task",
         "description": "Test Description",
+        "priority": "high",
     }
 
     mock_task = TaskResponse(
@@ -63,6 +63,7 @@ def test_create_new_task(mock_jwt_bearer, mock_create_task, mock_get_user_by_use
         title="Test Task",
         description="Test Description",
         status="todo",
+        priority="high",
         created_at=datetime.datetime.now(),
     )
 
@@ -84,6 +85,7 @@ def test_create_new_task(mock_jwt_bearer, mock_create_task, mock_get_user_by_use
     assert task_created["title"] == task_data["title"]
     assert task_created["description"] == task_data["description"]
     assert task_created["status"] == "todo"
+    assert task_created["priority"] == "high"
     assert task_created["created_at"] == mock_task.created_at.isoformat()
 
     app.dependency_overrides = {}
@@ -102,6 +104,7 @@ def test_create_new_task_user_not_found(mock_jwt_bearer, mock_get_user_by_userna
     task_data = {
         "title": "Test Task",
         "description": "Test Description",
+        "priority": "high",
     }
 
     mock_get_user_by_username.return_value = None
@@ -140,6 +143,7 @@ def test_create_new_task_internal_server_error(
     task_data = {
         "title": "Test Task",
         "description": "Test Description",
+        "priority": "high",
     }
 
     # Make the request to create a new task
@@ -181,6 +185,7 @@ def test_get_tasks_by_user(
         title="Task 1",
         description="Description 1",
         status="todo",
+        priority="high",
         created_at=datetime.datetime.now(),
     )
     mock_task2 = TaskResponse(
@@ -188,6 +193,7 @@ def test_get_tasks_by_user(
         title="Task 2",
         description="Description 2",
         status="todo",
+        priority="low",
         created_at=datetime.datetime.now(),
     )
     mock_get_tasks_by_user_id.return_value = [mock_task1, mock_task2]
@@ -204,9 +210,11 @@ def test_get_tasks_by_user(
     assert tasks[0]["title"] == mock_task1.title
     assert tasks[0]["description"] == mock_task1.description
     assert tasks[0]["status"] == mock_task1.status
+    assert tasks[0]["priority"] == mock_task1.priority
     assert tasks[1]["title"] == mock_task2.title
     assert tasks[1]["description"] == mock_task2.description
     assert tasks[1]["status"] == mock_task2.status
+    assert tasks[1]["priority"] == mock_task2.priority
 
     # Reset the overrides to not interfere with other tests
     app.dependency_overrides = {}
@@ -274,6 +282,7 @@ def test_update_task_success(mock_jwt_bearer, mock_update_task, mock_get_task_by
         "title": "Updated Task",
         "description": "Updated Description",
         "status": "done",
+        "priority": "high",
     }
 
     mock_task = TaskResponse(
@@ -281,6 +290,7 @@ def test_update_task_success(mock_jwt_bearer, mock_update_task, mock_get_task_by
         title="Updated Task",
         description="Updated Description",
         status="done",
+        priority="high",
         created_at=datetime.datetime.now(),
     )
 
@@ -304,6 +314,7 @@ def test_update_task_success(mock_jwt_bearer, mock_update_task, mock_get_task_by
     assert updated_task["title"] == updated_task_data["title"]
     assert updated_task["description"] == updated_task_data["description"]
     assert updated_task["status"] == "done"
+    assert updated_task["priority"] == "high"
 
     app.dependency_overrides = {}
 
@@ -320,6 +331,7 @@ def test_update_task_not_found(mock_jwt_bearer, mock_update_task):
         "title": "Updated Task",
         "description": "Updated Description",
         "status": "done",
+        "priority": "high",
     }
 
     headers = {"Authorization": "Bearer token"}
@@ -350,6 +362,7 @@ def test_update_task_internal_server_error(mock_jwt_bearer, mock_update_task):
         "title": "Updated Task",
         "description": "Updated Description",
         "status": "done",
+        "priority": "high",
     }
 
     headers = {"Authorization": "Bearer token"}


### PR DESCRIPTION
This pull request introduces a new `priority` field to tasks, including updates to the database schema, CRUD operations, and test cases to support this new attribute.

### Database and Model Changes:
* [`models/task.py`](diffhunk://#diff-382460ec8d319592278a2d21a0ee25c85c58dbdcc217120c9138925b0530dfd0L15-R16): Added `priority` field to `Task` model and adjusted the length of the `status` field.

### CRUD Operations:
* [`crud/task.py`](diffhunk://#diff-982081e8c6eac13fc8776804bf95157890e9ede851bf73f45bf88b71175a8ba0R75): Updated the `update_task` function to handle the new `priority` field.

### Schema Updates:
* [`schemas/task.py`](diffhunk://#diff-8b08b8c4f1e14482f90493cdd71b696ca2000596919bc70171d67a9db22b4b79R3-R25): Added `priority` field to `TaskCreate`, `TaskResponse`, and `TaskUpdate` schemas.

### Test Cases:
* [`tests/crud/test_task.py`](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01L91-R125): Updated test cases to include the `priority` field in task creation, update, and retrieval tests. [[1]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01L91-R125) [[2]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01L143-R149) [[3]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01R171) [[4]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01R180-R194) [[5]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01R207) [[6]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01R219)
* [`tests/routers/test_task.py`](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93L40): Updated test cases for task creation, update, and retrieval routes to include the `priority` field. [[1]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93L40) [[2]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R58-R66) [[3]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R88) [[4]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R107) [[5]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R146) [[6]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R188-R196) [[7]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R213-R217) [[8]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R285-R293) [[9]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R317) [[10]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R334) [[11]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R365)