### PR TITLE
Todo 12 set task deadline

### DIFF
--- a/models/task.py
+++ b/models/task.py
@@ -14,6 +14,7 @@ class Task(Base):
     description = Column(String(200))
     status = Column(String(6), default="todo", nullable=False)
     priority = Column(String(5), nullable=False)
+    deadline = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(
         DateTime(timezone=True),
         index=True,

--- a/routers/task.py
+++ b/routers/task.py
@@ -64,6 +64,12 @@ async def create_new_task(
         # Re-raise HTTP exceptions to maintain the status code
         raise http_exc
 
+    except ValueError as ve:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(ve),
+        )
+
     except Exception as e:
         logging.error(f"Failed to create task: {e}")
         raise HTTPException(
@@ -201,6 +207,12 @@ async def update_task_route(
     except HTTPException as http_exc:
         # Re-raise HTTP exceptions to maintain the status code
         raise http_exc
+
+    except ValueError as ve:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(ve),
+        )
 
     except Exception as e:
         logging.error(f"Failed to update task: {e}")

--- a/schemas/task.py
+++ b/schemas/task.py
@@ -7,6 +7,7 @@ class TaskCreate(BaseModel):
     title: str
     description: str
     priority: str
+    deadline: Optional[datetime] = None
 
 
 class TaskResponse(BaseModel):
@@ -15,6 +16,7 @@ class TaskResponse(BaseModel):
     description: str
     status: str
     priority: str
+    deadline: Optional[datetime] = None
     created_at: datetime
 
 
@@ -23,3 +25,4 @@ class TaskUpdate(BaseModel):
     description: str
     status: str
     priority: str
+    deadline: Optional[datetime] = None


### PR DESCRIPTION
This pull request introduces a new `deadline` field for tasks and includes validation to ensure deadlines are set in the future. Additionally, it handles `ValueError` exceptions in the task creation and update routes, and adds corresponding tests to ensure the new functionality works as expected.

### New Feature: Task Deadline

* [`models/task.py`](diffhunk://#diff-382460ec8d319592278a2d21a0ee25c85c58dbdcc217120c9138925b0530dfd0R17): Added a `deadline` field to the `Task` model.
* [`schemas/task.py`](diffhunk://#diff-8b08b8c4f1e14482f90493cdd71b696ca2000596919bc70171d67a9db22b4b79R10): Updated `TaskCreate`, `TaskResponse`, and `TaskUpdate` schemas to include the optional `deadline` field. [[1]](diffhunk://#diff-8b08b8c4f1e14482f90493cdd71b696ca2000596919bc70171d67a9db22b4b79R10) [[2]](diffhunk://#diff-8b08b8c4f1e14482f90493cdd71b696ca2000596919bc70171d67a9db22b4b79R19) [[3]](diffhunk://#diff-8b08b8c4f1e14482f90493cdd71b696ca2000596919bc70171d67a9db22b4b79R28)

### Validation

* [`crud/task.py`](diffhunk://#diff-982081e8c6eac13fc8776804bf95157890e9ede851bf73f45bf88b71175a8ba0R20-R21): Added validation in `create_task` and `update_task` functions to ensure the `deadline` is in the future. [[1]](diffhunk://#diff-982081e8c6eac13fc8776804bf95157890e9ede851bf73f45bf88b71175a8ba0R20-R21) [[2]](diffhunk://#diff-982081e8c6eac13fc8776804bf95157890e9ede851bf73f45bf88b71175a8ba0R79-R82)

### Exception Handling

* [`routers/task.py`](diffhunk://#diff-34a85b9525bb969b96c04301cd37cd66bb907856626d02f7b433ffee46539f86R67-R72): Added handling for `ValueError` exceptions in task creation and update routes, returning a `400 Bad Request` status code. [[1]](diffhunk://#diff-34a85b9525bb969b96c04301cd37cd66bb907856626d02f7b433ffee46539f86R67-R72) [[2]](diffhunk://#diff-34a85b9525bb969b96c04301cd37cd66bb907856626d02f7b433ffee46539f86R211-R216)

### Tests

* [`tests/crud/test_task.py`](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01L91-R100): Added tests for task creation and update with various `deadline` scenarios, including past, future, and no deadline. [[1]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01L91-R100) [[2]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01R114-R155) [[3]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01L163-R244) [[4]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01R253) [[5]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01R264) [[6]](diffhunk://#diff-869cf89a115f7095b5cc50b9907343025db372d394c8cee623db2074829f0b01R279-R346)
* [`tests/routers/test_task.py`](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R164-R204): Added tests to verify `ValueError` handling in the task creation and update routes. [[1]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R164-R204) [[2]](diffhunk://#diff-d99d4083946f4e27f9738a634dec7d1a54d041f94ec4065d8490bea0850d6b93R425-R466)